### PR TITLE
Fix order of displayed data from disk sensor

### DIFF
--- a/package/contents/ui/components/graph/DiskGraph.qml
+++ b/package/contents/ui/components/graph/DiskGraph.qml
@@ -8,7 +8,7 @@ RMBaseGraph.TwoSensorsGraph {
     objectName: "DiskGraph"
 
     // Settings
-    property string device: "all" // Device id (eg: sda, sdc) | Could be "all"
+    property string device: "all" // Device ID (e.g.: "sda" or "sdc"); could be "all"
     property bool icons: false
     readonly property var unit: Formatter.getUnitInfo("kibibyte", i18nc)
 
@@ -27,9 +27,9 @@ RMBaseGraph.TwoSensorsGraph {
 
     // Graph options
     realUplimits: [uplimits[0] * unit.multiplier, uplimits[1] * unit.multiplier]
-    sensorsModel.sensors: sensorsType[0] ? [`disk/${device}/read`, `disk/${device}/write`] : [`disk/${device}/write`, `disk/${device}/read`]
+    sensorsModel.sensors: sensorsType[0] ? [`disk/${device}/write`, `disk/${device}/read`] : [`disk/${device}/read`, `disk/${device}/write`]
 
-    // Override methods, for handle icons
+    // Override methods to handle icons
     _formatValue: (index, value) => {
         // Show icons
         let icon = ""
@@ -37,7 +37,7 @@ RMBaseGraph.TwoSensorsGraph {
             if (index === readIndex) {
                 icon = " " + i18nc("Disk graph icon : Read", " R")
             } else if (index == writeIndex) {
-                icon = " " + i18nc("Disk graph icon : Write", "W")
+                icon = " " + i18nc("Disk graph icon : Write", " W")
             }
         }
 

--- a/package/contents/ui/components/graph/DiskGraph.qml
+++ b/package/contents/ui/components/graph/DiskGraph.qml
@@ -37,7 +37,7 @@ RMBaseGraph.TwoSensorsGraph {
             if (index === readIndex) {
                 icon = " " + i18nc("Disk graph icon : Read", " R")
             } else if (index == writeIndex) {
-                icon = " " + i18nc("Disk graph icon : Write", " W")
+                icon = " " + i18nc("Disk graph icon : Write", "W")
             }
         }
 


### PR DESCRIPTION
When comparing read/write rate numbers from Plasma's system monitor sensor widget on the Desktop screen to Resource Monitor's numbers, I noticed things seemed swapped.

I checked `~/.config/plasma-org.kde.plasma.desktop-appletsrc` to make sure it wasn't a mistake I made when labelling sensors; my labels properly match the sensors: "Read" is for `disk/all/read`, for instance.

Then I went out to check the local Plasmoid code, and found that the values of the index constants (`readIndex` and `writeIndex`) were not logically paired to the sensor sources' positions in the `sensorModels.sensors` array.

In order for the position of the sensor paths to correspond to the established indexes, I changed the array's strings. After restarting Plasma, I see that the rates are matching again.

Such problem was specific to the Disk I/O graph, not occurring on, say, Memory or Network graphs. I cannot say for the other ones because I do not have them enabled.

As a few minor changes, I added a space before the "W" icon, which "R" already had, to make it consistent and more spaced on screen. There were also some pedantic improvements on spelling in comments for I think they look better that way when reading.