### PR TITLE
feat: add option to show temperature at the top-left corner of the graph

### DIFF
--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -46,6 +46,9 @@
         <entry name="graphFillOpacity" type="Int">
             <default>25</default>
         </entry>
+        <entry name="thirdLineToLeftTopCorner" type="Bool">
+            <default>false</default>
+        </entry>
 
         <entry name="enableShadows" type="Bool">
             <default>true</default>

--- a/package/contents/ui/components/graph/base/GraphText.qml
+++ b/package/contents/ui/components/graph/base/GraphText.qml
@@ -77,6 +77,7 @@ Item {
             id: secondLine
             readonly property int index: 1
             text: "..."
+            anchors.top: firstLine.bottom
 
             width: parent.width
             enabled: hints[index] !== ""
@@ -94,7 +95,8 @@ Item {
             readonly property int index: 2
             text: "..."
 
-            width: parent.width
+            anchors.top: Plasmoid.configuration.thirdLineToLeftTopCorner ? textContainer.top : secondLine.bottom
+            width: Plasmoid.configuration.thirdLineToLeftTopCorner ? 0.4 * parent.width : parent.width
             enabled: hints[index] !== ""
             visible: enabled
 

--- a/package/contents/ui/components/sensors/CpuTemperature.qml
+++ b/package/contents/ui/components/sensors/CpuTemperature.qml
@@ -1,4 +1,5 @@
 import QtQuick
+import org.kde.plasma.plasmoid
 import org.kde.ksysguard.sensors as Sensors
 import org.kde.ksysguard.formatter as Formatter
 import org.kde.plasma.plasma5support as Plasma5Support
@@ -27,7 +28,18 @@ Item {
     }
 
     function getFormattedValue() {
-        return Formatter.Formatter.formatValueShowNull(value, 1000 /* Formatter.Unit.UnitCelsius */);
+        // return Formatter.Formatter.formatValueWithPrecision(value, 1000 /* Formatter.Unit.UnitCelsius */,
+        //         Plasmoid.configuration.thirdLineToLeftTopCorner ? 0 : 1);
+        // // There should be `QString KSysGuard::FormatterWrapper::formatValueWithPrecision`, according to https://api.kde.org/plasma/libksysguard/html/classKSysGuard_1_1FormatterWrapper.html,
+        // // However in my environment this function does not exists. So, as workaround, I manually implements the precision control as below.
+
+        let result = Formatter.Formatter.formatValueShowNull(value, 1000 /* Formatter.Unit.UnitCelsius */);
+        if (Plasmoid.configuration.thirdLineToLeftTopCorner || true) {
+            let [_, resultNumber, resultUnit] = result.match(/(-?[\d.]+)(.*)/)
+            resultNumber = Number(resultNumber).toFixed(0)
+            result = resultNumber + resultUnit
+        }
+        return result
     }
 
     readonly property var _sensor: Sensors.Sensor {

--- a/package/contents/ui/config/ConfigAppearance.qml
+++ b/package/contents/ui/config/ConfigAppearance.qml
@@ -20,6 +20,7 @@ KCM.AbstractKCM {
     property alias cfg_graphHeight: graphHeight.value
     property alias cfg_graphSpacing: graphSpacing.value
     property alias cfg_graphFillOpacity: graphFillOpacity.value
+    property alias cfg_thirdLineToLeftTopCorner: thirdLineToLeftTopCorner.checked
 
     // Text
     property alias cfg_enableShadows: enableShadows.checked
@@ -159,6 +160,10 @@ KCM.AbstractKCM {
                     from: 0
                     to: 100
                     suffix: "%"
+                }
+                QQC2.CheckBox {
+                    id: thirdLineToLeftTopCorner
+                    text: i18n("Show temperature at the top-left corner?")
                 }
             }
 

--- a/package/contents/ui/config/ConfigGraph.qml
+++ b/package/contents/ui/config/ConfigGraph.qml
@@ -27,6 +27,7 @@ KCM.ScrollViewKCM {
     property var cfg_graphHeight
     property var cfg_graphSpacing
     property var cfg_graphFillOpacity
+    property var cfg_thirdLineToLeftTopCorner
     property var cfg_enableShadows
     property var cfg_fontScale
     property var cfg_placement

--- a/package/contents/ui/config/ConfigMisc.qml
+++ b/package/contents/ui/config/ConfigMisc.qml
@@ -21,6 +21,7 @@ KCM.SimpleKCM {
     property var cfg_graphHeight
     property var cfg_graphSpacing
     property var cfg_graphFillOpacity
+    property var cfg_thirdLineToLeftTopCorner
     property var cfg_enableShadows
     property var cfg_fontScale
     property var cfg_placement


### PR DESCRIPTION
I implements showing temperature at the top-left corner of the graph.

Implemetation Keypoints:
1. `ConfigAppearance.qml`: Adds a config item "Plasmoid.configuration.thirdLineToLeftTopCorner" 
2. `GraphText.qml`: Adding positioning anchors control codes in GraphText.qml. Please review the code.
3. `CpuTemperature.qml`: The temperature used to be shown with one decimal digit, such as "45.6°C". After moving the temperature to the top-left corner, This is not very beautiful as there will be nearly no space between the temperature and the percentage. so in `CpuTemperature.qml:getFormattedValue()`, precision control is implemented to keep the temperature always integer.