### PR TITLE
Fix typo in DiskGraph.qml

### DIFF
--- a/package/contents/ui/components/graph/DiskGraph.qml
+++ b/package/contents/ui/components/graph/DiskGraph.qml
@@ -35,7 +35,7 @@ RMBaseGraph.TwoSensorsGraph {
         let icon = ""
         if (root.icons) {
             if (index === readIndex) {
-                icon = " " + i18nc("Disk graph icon : Read", " R")
+                icon = " " + i18nc("Disk graph icon : Read", "R")
             } else if (index == writeIndex) {
                 icon = " " + i18nc("Disk graph icon : Write", "W")
             }


### PR DESCRIPTION
Fixes extra space before "R" in DiskGraph, that brakes "read" value UI/UX behaviour
![image](https://github.com/user-attachments/assets/ee9e84f9-16c6-4a79-8342-ba98a3f96700)
