### PR TITLE
Fix network text values not being displayed

### DIFF
--- a/package/contents/ui/components/text/NetworkText.qml
+++ b/package/contents/ui/components/text/NetworkText.qml
@@ -63,7 +63,7 @@ RMBase.BaseSensorText {
             downloadValue *= unit.byteDiff;
             uploadValue *= unit.byteDiff;
 
-            // Update labels
+            // Update labels 
             if (textContainer.enabled) {
                 _updateData(downloadIndex, downloadValue);
                 _updateData(uploadIndex, uploadValue);

--- a/package/contents/ui/components/text/NetworkText.qml
+++ b/package/contents/ui/components/text/NetworkText.qml
@@ -64,7 +64,7 @@ RMBase.BaseSensorText {
             uploadValue *= unit.byteDiff;
 
             // Update labels
-            if (textContainer.enabled && textContainer.valueVisible) {
+            if (textContainer.enabled) {
                 _updateData(downloadIndex, downloadValue);
                 _updateData(uploadIndex, uploadValue);
             }


### PR DESCRIPTION
Removed the check against the non-existent textContainer.valueVisible property in NetworkText.qml.